### PR TITLE
Fix Swift tools version spelling in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Hey there,
Thanks for sharing this package 🙏

I am some times getting the following error in a different project that uses this package as a dependency.

![Screenshot 2025-04-29 at 13 17 09](https://github.com/user-attachments/assets/8a1b3677-6c42-42e6-993e-c6c437199331)

I think the correct spelling for the intended version should be "6.0", the change fixed the error for me.

Cheers  👋 